### PR TITLE
DEV: Attempt to fix flaky test

### DIFF
--- a/spec/requests/discourse_logster_transporter/receiver_controller_spec.rb
+++ b/spec/requests/discourse_logster_transporter/receiver_controller_spec.rb
@@ -137,22 +137,37 @@ RSpec.describe DiscourseLogsterTransporter::ReceiverController do
 
           expect(response.status).to eq(200)
 
-          first_log = fake_store.logs.find { |log| log[0] == Logger::ERROR }
-
-          expect(first_log[1]).to eq("test1")
-          expect(first_log[2]).to eq("test2")
-          expect(first_log[3].keys).to contain_exactly("backtrace", "env")
-
-          expect(first_log[3][:env].keys).to contain_exactly(
-            "application_version",
-            "hostname",
-            "process_id",
+          expect(fake_store.logs).to include(
+            [
+              Logger::ERROR,
+              "test1",
+              "test2",
+              {
+                "env" => {
+                  "hostname" => "something",
+                  "process_id" => 241_213,
+                  "application_version" => "1234566",
+                },
+                "backtrace" => "something\nsomething",
+              },
+            ],
           )
 
-          second_log = fake_store.logs.find { |log| log[0] == Logger::WARN }
-
-          expect(second_log[1]).to eq("test3")
-          expect(second_log[2]).to eq("")
+          expect(fake_store.logs).to include(
+            [
+              Logger::WARN,
+              "test3",
+              "",
+              {
+                "env" => {
+                  "hostname" => "something",
+                  "process_id" => 1234,
+                  "application_version" => "2310313",
+                },
+                "backtrace" => "something\nsomething",
+              },
+            ],
+          )
         ensure
           Rails.logger = orig_logger
         end


### PR DESCRIPTION
Why this change?

The test flaked in
https://github.com/discourse/discourse/actions/runs/6383687172/job/17324811876
which may be due to the fact that we expect the logs to be in a certain
order.

What does this change do?

Instead of assuming a certain order of logs in the "FakeStore", we just
ensure that the log is present.