### PR TITLE
DEV: Avoid reassigning Rails.logger in tests

### DIFF
--- a/spec/requests/discourse_logster_transporter/receiver_controller_spec.rb
+++ b/spec/requests/discourse_logster_transporter/receiver_controller_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe DiscourseLogsterTransporter::ReceiverController do
             },
           ]
 
-          orig_logger = Rails.logger
           fake_store = FakeStore.new
-          Rails.logger = ::Logster::Logger.new(fake_store)
+          fake_logger = ::Logster::Logger.new(fake_store)
+          Rails.logger.broadcast_to(fake_logger)
 
           post "/discourse-logster-transport/receive.json",
                params: {
@@ -169,7 +169,7 @@ RSpec.describe DiscourseLogsterTransporter::ReceiverController do
             ],
           )
         ensure
-          Rails.logger = orig_logger
+          Rails.logger.stop_broadcasting_to(fake_logger)
         end
       end
     end


### PR DESCRIPTION
Reassign Rails.logger in tests can lead to flaky tests and is no longer
allowed. This commit updates the test to use `Rails.logger.broadcast_to`
instead.

#### Reviewer notee

See https://github.com/discourse/discourse/pull/31920